### PR TITLE
quill + flyway

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,13 +41,18 @@ lazy val libraries = Seq(
   "dev.zio"                     %% "zio-mock"                % "1.0.0-RC8" % "it, test",
   "dev.zio"                     %% "zio-config"              % zioConfigVersion,
   "dev.zio"                     %% "zio-config-magnolia"     % zioConfigVersion,
-  "dev.zio"                     %% "zio-config-typesafe"     % zioConfigVersion
+  "dev.zio"                     %% "zio-config-typesafe"     % zioConfigVersion,
+  "io.getquill"                 %% "quill-jdbc-zio"          % "4.4.1",
+  "org.postgresql"               % "postgresql"              % "42.5.0",
+  "org.flywaydb"                 % "flyway-core"             % "9.3.1"
 )
 
 lazy val root = (project in file("."))
+  .configs(IntegrationTest)
   .settings(
     name := "zio-project-playground",
-    libraryDependencies ++= libraries
+    libraryDependencies ++= libraries,
+    Defaults.itSettings
   )
 
 addCommandAlias("fmt", "all root/scalafmtSbt root/scalafmtAll")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  it-db:
+    image: postgres:latest
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_HOST_AUTH_METHOD: trust

--- a/src/it/resources/logback-test.xml
+++ b/src/it/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="io.netty" level="ERROR"/>
+    <logger name="org.flywaydb" level="ERROR"/>
+    <logger name="com.zaxxer" level="ERROR"/>
+    <logger name="io.getquill.context.jdbc" level="ERROR"/>
+
+</configuration>

--- a/src/it/scala/repositories/users/UserRepositoryITSpec.scala
+++ b/src/it/scala/repositories/users/UserRepositoryITSpec.scala
@@ -1,0 +1,62 @@
+package repositories.users
+
+import domain.records.UserRecord
+import repositories.Repository
+import services.flyway.{FlywayService, FlywayServiceLive}
+import zio.Scope
+import zio.test._
+import zio._
+
+// NOTE - for now, will need to docker-compose down/up between runs to clear database.
+// WIll add some auto clean-up functionality (or test-containers) later
+object UserRepositoryITSpec extends ZIOSpecDefault {
+
+  val someUser: UserRecord =
+    UserRecord(-1, "alterationx10", "supersecretpwhash")
+
+  val tests: Spec[UserRepository, Throwable] = suite("UserRepository")(
+    test("create")(
+      for {
+        _ <- ZIO.serviceWithZIO[UserRepository](_.create(someUser))
+      } yield assertCompletes
+    ),
+    test("getById")(
+      for {
+        created <- ZIO.serviceWithZIO[UserRepository](_.create(someUser))
+        fetched <- ZIO.serviceWithZIO[UserRepository](_.getById(created.id))
+      } yield assertTrue(fetched.contains(created))
+    ),
+    test("update")(
+      for {
+        created <- ZIO
+                     .serviceWithZIO[UserRepository](_.create(someUser))
+        updated <-
+          ZIO.serviceWithZIO[UserRepository](
+            _.update(created.id, rec => rec.copy(pwHash = "uweulhwauwhae"))
+          )
+        fetched <- ZIO
+                     .serviceWithZIO[UserRepository](_.getById(created.id))
+      } yield assertTrue(fetched.contains(updated))
+    ),
+    test("delete")(
+      for {
+        created <- ZIO.serviceWithZIO[UserRepository](_.create(someUser))
+        _       <- ZIO.serviceWithZIO[UserRepository](_.delete(created.id))
+        fetched <- ZIO.serviceWithZIO[UserRepository](_.getById(created.id))
+      } yield assertTrue(fetched.isEmpty)
+    )
+  )
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("UserRepositoryITSpec")(
+      tests
+    ).provide(
+      Repository.dataSourceLayer,
+      Repository.quillPostgresLayer,
+      UserRepositoryLive.layer
+    ) @@ TestAspect.sequential @@ TestAspect.beforeAll(
+      ZIO
+        .serviceWithZIO[FlywayService](_.runMigrations)
+        .provideLayer(FlywayServiceLive.layer)
+    )
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,19 @@
+rock.the.jvm {
+  db {
+    hikari-postgres {
+        poolName = "quill"
+        maximumPoolSize = 5
+        connectionTimeout = 30000
+        transactionIsolation = TRANSACTION_SERIALIZABLE
+        dataSourceClassName = org.postgresql.ds.PGSimpleDataSource
+        dataSource {
+          url = "jdbc:postgresql://localhost:5432/postgres"
+          url = ${?DATABASE_JDBC_URL}
+          user = "postgres"
+          user = ${?DATABASE_USER}
+          password = ""
+          password = ${?DATABASE_PASS}
+        }
+      }
+  }
+}

--- a/src/main/resources/db/migration/V1__create_users_table.sql
+++ b/src/main/resources/db/migration/V1__create_users_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS "users"
+(
+    "id"        BIGSERIAL PRIMARY KEY,
+    "user_name" TEXT NOT NULL,
+    "pw_hash"   TEXT NOT NULL
+);
+CREATE INDEX "user_name_idx" ON "users" ("user_name");

--- a/src/main/scala/domain/errors/DatabaseError.scala
+++ b/src/main/scala/domain/errors/DatabaseError.scala
@@ -1,0 +1,4 @@
+package domain.errors
+
+case class DatabaseError(message: String, cause: Throwable)
+    extends DatabaseException(message, cause)

--- a/src/main/scala/domain/records/UserRecord.scala
+++ b/src/main/scala/domain/records/UserRecord.scala
@@ -1,0 +1,7 @@
+package domain.records
+
+case class UserRecord(
+    id: Int,
+    userName: String,
+    pwHash: String
+)

--- a/src/main/scala/repositories/Repository.scala
+++ b/src/main/scala/repositories/Repository.scala
@@ -1,0 +1,18 @@
+package repositories
+
+import io.getquill.SnakeCase
+import io.getquill.jdbczio.Quill
+import zio.ZLayer
+
+import javax.sql.DataSource
+
+object Repository {
+
+  val quillPostgresLayer
+      : ZLayer[DataSource, Nothing, Quill.Postgres[SnakeCase.type]] =
+    Quill.Postgres.fromNamingStrategy(SnakeCase)
+
+  val dataSourceLayer: ZLayer[Any, Throwable, DataSource] =
+    Quill.DataSource.fromPrefix("rock.the.jvm.db.hikari-postgres")
+
+}

--- a/src/main/scala/repositories/users/UserRepository.scala
+++ b/src/main/scala/repositories/users/UserRepository.scala
@@ -1,0 +1,66 @@
+package repositories.users
+
+import domain.records.UserRecord
+import io.getquill._
+import io.getquill.jdbczio.Quill
+import zio._
+
+trait UserRepository {
+  def create(record: UserRecord): Task[UserRecord]
+  def update(id: Int, op: UserRecord => UserRecord): Task[UserRecord]
+  def getById(id: Int): Task[Option[UserRecord]]
+  def delete(id: Int): Task[UserRecord]
+}
+
+case class UserRepositoryLive(quill: Quill.Postgres[SnakeCase])
+    extends UserRepository {
+
+  import quill._
+
+  implicit val schema =
+    schemaMeta[UserRecord]("users")
+
+  implicit val userInsertMeta =
+    insertMeta[UserRecord](_.id)
+
+  implicit val userUpdateMeta =
+    updateMeta[UserRecord](_.id)
+
+  override def create(record: UserRecord): Task[UserRecord] =
+    run(query[UserRecord].insertValue(lift(record)).returning(r => r))
+
+  override def update(
+      id: Int,
+      op: UserRecord => UserRecord
+  ): Task[UserRecord] = {
+    for {
+      current <- getById(id).someOrFail(
+                   new Exception(s"Could not update due to missing id $id")
+                 )
+      updated <-
+        run(
+          query[UserRecord]
+            .filter(_.id == lift(id))
+            .updateValue(lift(op(current)))
+            .returning(r => r)
+        )
+    } yield updated
+  }
+
+  override def getById(id: Int): Task[Option[UserRecord]] =
+    run(query[UserRecord].filter(_.id == lift(id))).map(_.headOption)
+
+  override def delete(id: Int): Task[UserRecord] =
+    run(query[UserRecord].filter(_.id == lift(id)).delete.returning(r => r))
+}
+
+object UserRepositoryLive {
+
+  val layer: ZLayer[Quill.Postgres[SnakeCase], Nothing, UserRepositoryLive] =
+    ZLayer {
+      for {
+        quill <- ZIO.service[Quill.Postgres[SnakeCase]]
+      } yield UserRepositoryLive(quill)
+    }
+
+}

--- a/src/main/scala/services/flyway/FlywayService.scala
+++ b/src/main/scala/services/flyway/FlywayService.scala
@@ -1,0 +1,117 @@
+package services.flyway
+
+import org.flywaydb.core.Flyway
+import services.config.ConfigService
+import zio._
+
+import scala.jdk.CollectionConverters._
+
+trait FlywayService {
+  def clean: Task[Unit]
+
+  def runBaseline: Task[Unit]
+
+  def runMigrations: Task[Unit]
+
+  def repairMigrations: Task[Unit]
+}
+
+case class FlywayServiceLive(flyway: Flyway) extends FlywayService {
+
+  override def clean: Task[Unit] = {
+    for {
+      result <- ZIO.attemptBlocking(flyway.clean())
+      _      <-
+        ZIO.logDebug(
+          s"Schemas Cleaned:\n ${result.schemasCleaned.asScala.map(c => s"\t$c\n")}"
+        )
+      _      <-
+        ZIO.logDebug(
+          s"Schemas Dropped:\n ${result.schemasDropped.asScala.map(c => s"\t$c\n")}"
+        )
+      _      <-
+        ZIO.logDebug(
+          s"Clean Warnings:\n ${result.warnings.asScala.map(c => s"\t$c\n")}"
+        )
+    } yield ()
+  }
+
+  override def runBaseline: Task[Unit] =
+    for {
+      result <- ZIO.attemptBlocking(flyway.baseline())
+      _      <-
+        ZIO.logDebug(
+          s"Baselined: ${result.successfullyBaselined}"
+        )
+      _      <-
+        ZIO.logDebug(
+          s"Baseline Warnings:\n ${result.warnings.asScala.map(c => s"\t$c\n")}"
+        )
+    } yield ()
+
+  override def runMigrations: Task[Unit] =
+    for {
+      result <- ZIO.attemptBlocking(flyway.migrate())
+      _      <-
+        ZIO.logDebug(
+          s"Migrations Ran:\n ${result.migrations.asScala
+              .map(c => s"\t${c.filepath}\n")}"
+        )
+      _      <-
+        ZIO.logDebug(
+          s"Migration Warnings:\n ${result.warnings.asScala.map(c => s"\t$c\n")}"
+        )
+    } yield ()
+
+  override def repairMigrations: Task[Unit] =
+    for {
+      result <- ZIO.attemptBlocking(flyway.repair())
+      _      <-
+        ZIO.logDebug(
+          s"Repair Actions:\n ${result.repairActions.asScala
+              .map(c => s"\t$c\n")}"
+        )
+      _      <-
+        ZIO.logDebug(
+          s"Repair Aligned:\n ${result.migrationsAligned.asScala
+              .map(c => s"\t${c.filepath}\n")}"
+        )
+      _      <-
+        ZIO.logDebug(
+          s"Repair Removed:\n ${result.migrationsRemoved.asScala
+              .map(c => s"\t${c.filepath}\n")}"
+        )
+      _      <-
+        ZIO.logDebug(
+          s"Repair Deleted:\n ${result.migrationsDeleted.asScala
+              .map(c => s"\t${c.filepath}\n")}"
+        )
+      _      <-
+        ZIO.logDebug(
+          s"Repair Warnings:\n ${result.warnings.asScala.map(c => s"\t$c\n")}"
+        )
+    } yield ()
+}
+
+object FlywayServiceLive {
+
+  private val _layer = ZLayer {
+    for {
+      config <- ZIO.service[Config]
+      flyway <- ZIO.attempt(
+                  Flyway
+                    .configure()
+                    .dataSource(config.url, config.user, config.password)
+                    .load()
+                )
+    } yield FlywayServiceLive(flyway)
+  }
+
+  val layer: ZLayer[Scope, Throwable, FlywayService] = {
+    ConfigService.makeConfig[Config](
+      "rock.the.jvm.db.hikari-postgres.dataSource"
+    ) >>> _layer
+
+  }
+
+}

--- a/src/main/scala/services/flyway/package.scala
+++ b/src/main/scala/services/flyway/package.scala
@@ -1,0 +1,7 @@
+package services
+
+package object flyway {
+
+  case class Config(url: String, user: String, password: String)
+
+}


### PR DESCRIPTION
This adds in quill support as well as flyway for handling database migrations. A simple UserRecord repository is implemented, and has integration tests.