### PR TITLE
set up backend client + lib updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ This submodule is a ScalaJS app. To run in, you should `sbt> app/fastOptJS` (or
 `~fastOptJS` if you want watch for changes).
 
 You should then `docker-compose up nginx` which will host the files from a
-web server, and be accessible from `http://localhost:8080`.
+web server, and be accessible from `http://localhost:3000`.

--- a/app/src/main/scala/clients/backend/BackEndClient.scala
+++ b/app/src/main/scala/clients/backend/BackEndClient.scala
@@ -1,0 +1,86 @@
+package clients.backend
+
+import domain.api.request.{LoginForm, RegisterAccountRequest}
+import domain.api.response.{TokenResponse, User}
+import endpoints.{HealthEndpoints, UserEndpoints}
+import sttp.capabilities.zio.ZioStreams
+import sttp.client3._
+import sttp.client3.impl.zio.FetchZioBackend
+import sttp.model.Uri
+import sttp.tapir.client.sttp.SttpClientInterpreter
+import zio._
+
+import java.time.Instant
+
+trait BackEndClient {
+
+  def createAccount(request: RegisterAccountRequest): Task[User]
+  def fetchToken(request: LoginForm): Task[TokenResponse]
+  def fetchTime(): Task[Instant]
+  def fetchTimeSecure(): Task[Instant]
+
+}
+
+case class BackEndClientConfig(uri: Option[Uri])
+
+case class BackEndClientLive(
+    backend: SttpBackend[Task, ZioStreams],
+    config: BackEndClientConfig
+) extends BackEndClient {
+
+  val health = new HealthEndpoints {}
+  val user   = new UserEndpoints {}
+
+  val interpreter: SttpClientInterpreter = SttpClientInterpreter()
+
+  override def createAccount(request: RegisterAccountRequest): Task[User] = {
+
+    val _request: RegisterAccountRequest => Request[User, Any] =
+      interpreter.toRequestThrowErrors(user.registerEndpoint, config.uri)
+
+    backend.send(_request(request)).map(_.body)
+
+  }
+
+  override def fetchToken(request: LoginForm): Task[TokenResponse] = {
+
+    val _request: LoginForm => Request[TokenResponse, Any] =
+      interpreter.toRequestThrowErrors(user.generateTokenEndpoint, config.uri)
+
+    backend.send(_request(request).header("X-FETCH-TOKEN", "true")).map(_.body)
+
+  }
+
+  override def fetchTime(): Task[Instant] = {
+
+    val _request: Unit => Request[Instant, Any] =
+      interpreter.toRequestThrowErrors(health.timeEndpoint, config.uri)
+
+    backend.send(_request(())).map(_.body)
+
+  }
+
+  override def fetchTimeSecure(): Task[Instant] = {
+
+    val _request: String => Unit => Request[Instant, Any] =
+      interpreter.toSecureRequestThrowErrors(
+        health.secureTimeEndpoint,
+        config.uri
+      )
+
+    // We send an empty string here, because we're going to rely on a DelegateSttpBackend
+    backend.send(_request("")(())).map(_.body)
+  }
+
+}
+
+object BackEndClientLive {
+
+  lazy val live: BackEndClientLive = BackEndClientLive(
+    BearerBackend(FetchZioBackend()),
+    BackEndClientConfig(
+      uri = Some(uri"http://localhost:8080")
+    )
+  )
+
+}

--- a/app/src/main/scala/clients/backend/BearerBackend.scala
+++ b/app/src/main/scala/clients/backend/BearerBackend.scala
@@ -1,0 +1,42 @@
+package clients.backend
+
+import domain.api.response.TokenResponse
+import sttp.capabilities
+import sttp.capabilities.zio.ZioStreams
+import sttp.client3.{DelegateSttpBackend, Request, Response, SttpBackend}
+import zio.{Task, ZIO}
+import org.scalajs.dom
+
+case class BearerBackend(
+    delegate: SttpBackend[Task, ZioStreams]
+) extends DelegateSttpBackend[Task, ZioStreams](delegate = delegate) {
+
+  val tokenKey: String = "token"
+
+  override def send[T, R >: ZioStreams with capabilities.Effect[Task]](
+      request: Request[T, R]
+  ): Task[Response[T]] = {
+
+    val _newRequest = if (request.header("Authorization").isDefined) {
+      request.auth.bearer(dom.window.localStorage.getItem(tokenKey))
+    } else {
+      request
+    }
+
+    delegate
+      .send(_newRequest)
+      .tap { response =>
+        ZIO
+          .attempt(
+            dom.window.localStorage.setItem(
+              tokenKey,
+              response.body.asInstanceOf[TokenResponse].accessToken
+            )
+          )
+          .when(request.header("X-FETCH-TOKEN").isDefined)
+          .tapError(_ => ZIO.logError("Unable to store token automatically"))
+          .ignore
+      }
+
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -28,14 +28,15 @@ lazy val common = crossProject(JVMPlatform, JSPlatform)
   .settings(
     name := "zio-project-playground-common",
     libraryDependencies ++= Seq(
-      "com.softwaremill.sttp.tapir"   %%% "tapir-sttp-client" % Dependencies.tapirVersion,
-      "com.softwaremill.sttp.tapir"   %%% "tapir-json-zio"    % Dependencies.tapirVersion, // brings in zio-json
-      "com.softwaremill.sttp.client3" %%% "zio"               % Dependencies.sttpVersion
+      "com.softwaremill.sttp.tapir"   %%% "tapir-sttp-client"  % Dependencies.tapirVersion,
+//      "com.softwaremill.sttp.tapir"   %%% "tapir-json-zio"     % Dependencies.tapirVersion, // brings in zio-json
+      "com.softwaremill.sttp.tapir"   %%% "tapir-json-upickle" % Dependencies.tapirVersion,
+      "com.softwaremill.sttp.client3" %%% "zio"                % Dependencies.sttpVersion
     )
   )
   .jsSettings(
     libraryDependencies ++= Seq(
-      "io.github.cquiroz" %%% "scala-java-time" % "2.2.0" // implementations of java.time classes for Scala.JS
+      "io.github.cquiroz" %%% "scala-java-time" % "2.5.0" // implementations of java.time classes for Scala.JS
     )
   )
 

--- a/common/src/main/scala/domain/api/request/DeleteAccountRequest.scala
+++ b/common/src/main/scala/domain/api/request/DeleteAccountRequest.scala
@@ -1,6 +1,6 @@
 package domain.api.request
 
-import zio.json.{DeriveJsonCodec, JsonCodec}
+import upickle.default._
 
 case class DeleteAccountRequest(
     userName: String,
@@ -8,6 +8,6 @@ case class DeleteAccountRequest(
 )
 
 object DeleteAccountRequest {
-  implicit val codec: JsonCodec[DeleteAccountRequest] =
-    DeriveJsonCodec.gen[DeleteAccountRequest]
+  implicit val rw: ReadWriter[DeleteAccountRequest] = macroRW
+
 }

--- a/common/src/main/scala/domain/api/request/LoginForm.scala
+++ b/common/src/main/scala/domain/api/request/LoginForm.scala
@@ -1,9 +1,10 @@
 package domain.api.request
 
-import zio.json.{DeriveJsonCodec, JsonCodec}
+import upickle.default._
 
 case class LoginForm(username: String, password: String)
 
 object LoginForm {
-  implicit val codec: JsonCodec[LoginForm] = DeriveJsonCodec.gen[LoginForm]
+  implicit val rw: ReadWriter[LoginForm] = macroRW
+
 }

--- a/common/src/main/scala/domain/api/request/RegisterAccountRequest.scala
+++ b/common/src/main/scala/domain/api/request/RegisterAccountRequest.scala
@@ -1,6 +1,6 @@
 package domain.api.request
 
-import zio.json.{DeriveJsonCodec, JsonCodec}
+import upickle.default._
 
 case class RegisterAccountRequest(
     userName: String,
@@ -8,6 +8,6 @@ case class RegisterAccountRequest(
 )
 
 object RegisterAccountRequest {
-  implicit val codec: JsonCodec[RegisterAccountRequest] =
-    DeriveJsonCodec.gen[RegisterAccountRequest]
+  implicit val rw: ReadWriter[RegisterAccountRequest] = macroRW
+
 }

--- a/common/src/main/scala/domain/api/request/UpdatePasswordRequest.scala
+++ b/common/src/main/scala/domain/api/request/UpdatePasswordRequest.scala
@@ -1,6 +1,6 @@
 package domain.api.request
 
-import zio.json.{DeriveJsonCodec, JsonCodec}
+import upickle.default._
 
 case class UpdatePasswordRequest(
     userName: String,
@@ -9,6 +9,6 @@ case class UpdatePasswordRequest(
 )
 
 object UpdatePasswordRequest {
-  implicit val codec: JsonCodec[UpdatePasswordRequest] =
-    DeriveJsonCodec.gen[UpdatePasswordRequest]
+  implicit val rw: ReadWriter[UpdatePasswordRequest] = macroRW
+
 }

--- a/common/src/main/scala/domain/api/response/Company.scala
+++ b/common/src/main/scala/domain/api/response/Company.scala
@@ -1,9 +1,9 @@
 package domain.api.response
 
-import zio.json.{DeriveJsonCodec, JsonCodec}
+import upickle.default._
 
 case class Company ()
 
 object Company {
-  implicit val codec: JsonCodec[Company] = DeriveJsonCodec.gen[Company]
+  implicit val rw: ReadWriter[Company] = macroRW
 }

--- a/common/src/main/scala/domain/api/response/TokenResponse.scala
+++ b/common/src/main/scala/domain/api/response/TokenResponse.scala
@@ -1,12 +1,11 @@
 package domain.api.response
 
-import zio.json._
+import upickle.default._
 
 case class TokenResponse(
     accessToken: String
 )
 
 object TokenResponse {
-  implicit val codec: JsonCodec[TokenResponse] =
-    DeriveJsonCodec.gen[TokenResponse]
+  implicit val rw: ReadWriter[TokenResponse] = macroRW
 }

--- a/common/src/main/scala/domain/api/response/User.scala
+++ b/common/src/main/scala/domain/api/response/User.scala
@@ -1,9 +1,9 @@
 package domain.api.response
 
-import zio.json.{DeriveJsonCodec, JsonCodec}
+import upickle.default._
 
 case class User(userName: String)
 
 object User {
-  implicit val codec: JsonCodec[User] = DeriveJsonCodec.gen[User]
+  implicit val rw: ReadWriter[User] = macroRW
 }

--- a/common/src/main/scala/endpoints/CompanyEndpoints.scala
+++ b/common/src/main/scala/endpoints/CompanyEndpoints.scala
@@ -3,7 +3,7 @@ package endpoints
 import domain.api.response.Company
 import sttp.tapir._
 import sttp.tapir.generic.auto.schemaForCaseClass
-import sttp.tapir.json.zio.jsonBody
+import sttp.tapir.json.upickle.jsonBody
 
 
 trait CompanyEndpoints extends BaseEndpoint {

--- a/common/src/main/scala/endpoints/HealthEndpoints.scala
+++ b/common/src/main/scala/endpoints/HealthEndpoints.scala
@@ -23,4 +23,13 @@ trait HealthEndpoints extends BaseEndpoint {
       .get
       .in("health" / "time")
       .out(plainBody[Instant])
+
+  val secureTimeEndpoint: Endpoint[String, Unit, Throwable, Instant, Any] =
+    secureBearerEndpoint
+      .tag("time")
+      .name("secureTime")
+      .description("Get the current time as an authed user")
+      .get
+      .in("health" / "sec-time")
+      .out(plainBody[Instant])
 }

--- a/common/src/main/scala/endpoints/UserEndpoints.scala
+++ b/common/src/main/scala/endpoints/UserEndpoints.scala
@@ -4,7 +4,7 @@ import domain.api.request.{DeleteAccountRequest, LoginForm, RegisterAccountReque
 import domain.api.response.{TokenResponse, User}
 import sttp.tapir._
 import sttp.tapir.generic.auto.schemaForCaseClass
-import sttp.tapir.json.zio._
+import sttp.tapir.json.upickle.jsonBody
 
 trait UserEndpoints extends BaseEndpoint {
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
   nginx:
     image: nginx:latest
     ports:
-      - "8080:80"
+      - "3000:80"
     volumes:
       - ./app/src/main/resources/index.html:/usr/share/nginx/html/index.html
       - ./app/target/scala-2.13/zio-project-playground-app-fastopt.js:/usr/share/nginx/html/zio-project-playground-app-fastopt.js

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,9 +2,9 @@ import sbt._
 
 object Dependencies {
 
-  val zioVersion        = "2.0.2"
-  val tapirVersion      = "1.2.0"
-  val zioLoggingVersion = "2.1.3"
+  val zioVersion        = "2.0.4"
+  val tapirVersion      = "1.2.3"
+  val zioLoggingVersion = "2.1.5"
   val zioConfigVersion  = "3.0.2"
   val sttpVersion       = "3.8.3"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,6 @@ addSbtPlugin("nl.gn0s1s"          % "sbt-dotenv"               % "3.0.0")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"             % "2.3.0")
 addSbtPlugin("com.typesafe.sbt"   % "sbt-native-packager"      % "1.4.1")
 addSbtPlugin("ch.epfl.scala"      % "sbt-scalafix"             % "0.10.3")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.11.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.12.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
 addDependencyTreePlugin

--- a/server/src/main/scala/Main.scala
+++ b/server/src/main/scala/Main.scala
@@ -10,14 +10,10 @@ import sttp.tapir.server.interceptor.cors.CORSInterceptor
 import sttp.tapir.server.ziohttp.{ZioHttpInterpreter, ZioHttpServerOptions}
 import sttp.tapir.swagger.bundle.SwaggerInterpreter
 import zio._
-import zhttp.service.Server
+import zio.http.Server
 import zio.logging.backend.SLF4J
 
 object Main extends ZIOAppDefault {
-
-  /** The port the web server will run on.
-    */
-  val port = 9000
 
   /** A method to build our BaseController implementations, and return them as a
     * Seq. All Controllers should be injected here. Since we should be building
@@ -61,30 +57,29 @@ object Main extends ZIOAppDefault {
   /** Our main server application
     */
   val program: ZIO[
-    UserService with FlywayService with JWTService,
+    Server with UserService with JWTService with FlywayService,
     Throwable,
     ExitCode
   ] = for {
     _           <- initMigrations
     controllers <- makeControllers
     routes      <- gatherRoutes(controllers)
-    _           <- ZIO.log(s"ZIO Project running at http://localhost:$port baby!")
-    _           <- ZIO.log(s"Check the docs at http://localhost:$port/docs")
-    _           <-
-      Server.start(
-        port,
-        ZioHttpInterpreter[Any](
-          ZioHttpServerOptions.default.appendInterceptor(
-            CORSInterceptor.default
-          )
-        ).toHttp(routes)
-      )
+    _           <- ZIO.log(s"ZIO Project running at http://localhost:8080 baby!")
+    _           <- ZIO.log(s"Check the docs at http://localhost:8080/docs")
+    _           <- Server.serve(
+                     ZioHttpInterpreter[Any](
+                       ZioHttpServerOptions.default.appendInterceptor(
+                         CORSInterceptor.default
+                       )
+                     ).toHttp(routes)
+                   )
   } yield ExitCode.success
 
   override def run: ZIO[Any, Throwable, ExitCode] =
     program
       .provide(
         Scope.default,
+        Server.default,
         Repository.dataSourceLayer,
         Repository.quillPostgresLayer,
         FlywayServiceLive.configuredLayer,

--- a/server/src/main/scala/services/flyway/FlywayService.scala
+++ b/server/src/main/scala/services/flyway/FlywayService.scala
@@ -96,9 +96,9 @@ case class FlywayServiceLive(flyway: Flyway) extends FlywayService {
 
 object FlywayServiceLive {
 
-  val layer: ZLayer[Config, Throwable, FlywayService] = ZLayer {
+  val layer: ZLayer[FlywayConfig, Throwable, FlywayService] = ZLayer {
     for {
-      config <- ZIO.service[Config]
+      config <- ZIO.service[FlywayConfig]
       flyway <- ZIO.attempt(
                   Flyway
                     .configure()
@@ -109,7 +109,7 @@ object FlywayServiceLive {
   }
 
   val configuredLayer: ZLayer[Scope, Throwable, FlywayService] = {
-    ConfigService.makeConfig[Config](
+    ConfigService.makeConfig[FlywayConfig](
       "rock.the.jvm.db.hikari-postgres.dataSource"
     ) >>> layer
 
@@ -120,7 +120,7 @@ object FlywayServiceLive {
     ZLayer {
       for {
         container <- ZIO.service[PostgreSQLContainer]
-      } yield services.flyway.Config(
+      } yield services.flyway.FlywayConfig(
         url = container.jdbcUrl,
         user = container.username,
         password = container.password

--- a/server/src/main/scala/services/flyway/package.scala
+++ b/server/src/main/scala/services/flyway/package.scala
@@ -2,6 +2,6 @@ package services
 
 package object flyway {
 
-  case class Config(url: String, user: String, password: String)
+  case class FlywayConfig(url: String, user: String, password: String)
 
 }

--- a/server/src/main/scala/services/jwt/JWTService.scala
+++ b/server/src/main/scala/services/jwt/JWTService.scala
@@ -14,7 +14,7 @@ trait JWTService {
   def verifyToken(token: String): Task[ValidatedUserToken]
 }
 
-case class JWTServiceLive(config: Config, javaClock: java.time.Clock)
+case class JWTServiceLive(config: JwtConfig, javaClock: java.time.Clock)
     extends JWTService {
 
   private final val algorithm: Algorithm = {
@@ -71,14 +71,14 @@ case class JWTServiceLive(config: Config, javaClock: java.time.Clock)
 
 object JWTServiceLive {
 
-  val layer: ZLayer[Config, Nothing, JWTService] = ZLayer {
+  val layer: ZLayer[JwtConfig, Nothing, JWTService] = ZLayer {
     for {
-      config <- ZIO.service[Config]
+      config <- ZIO.service[JwtConfig]
       clock  <- Clock.javaClock
     } yield JWTServiceLive(config, clock)
   }
 
   val configuredLayer: ZLayer[Any, Throwable, JWTService] =
-    ConfigService.makeConfig[Config]("rock.the.jvm.jwt") >>> layer
+    ConfigService.makeConfig[JwtConfig]("rock.the.jvm.jwt") >>> layer
 
 }

--- a/server/src/main/scala/services/jwt/package.scala
+++ b/server/src/main/scala/services/jwt/package.scala
@@ -2,7 +2,7 @@ package services
 
 package object jwt {
 
-  case class Config(
+  case class JwtConfig(
       secret: Option[String],
       ttl: Int
   )

--- a/server/src/test/scala/services/jwt/JWTServiceSpec.scala
+++ b/server/src/test/scala/services/jwt/JWTServiceSpec.scala
@@ -13,8 +13,8 @@ object JWTServiceSpec extends ZIOSpecDefault {
   val JWTService: ZIO.ServiceWithZIOPartiallyApplied[JWTService] =
     ZIO.serviceWithZIO[JWTService]
 
-  val tokenTtl           = 10
-  val someConfig: Config = Config(secret = Option.empty, ttl = tokenTtl)
+  val tokenTtl              = 10
+  val someConfig: JwtConfig = JwtConfig(secret = Option.empty, ttl = tokenTtl)
 
   val tests = suite("JWTService")(
     test("generate / validate token") {


### PR DESCRIPTION
- ScalaJs was _not_ happy with zio json encoder/decoders - switch to upickle
- update libraries, now uses zio-http artifact + new config
- set up BackEndClient for the frontend app to use
- set up BearerBackend SttpDelegate to automagically handle tokens for us

BackEndClient still needs some cleanup. Kind of awkward to call unsafe-run-to-future. Might just be better to make it Future based from the start.