### PR TITLE
add some basic views for company info

### DIFF
--- a/app/src/main/scala/Main.scala
+++ b/app/src/main/scala/Main.scala
@@ -5,6 +5,7 @@ import org.scalajs.dom
 import pages.{
   AboutPage,
   CompaniesPage,
+  CompanyPage,
   CreateCompanyPage,
   HomePage,
   LoginPage,
@@ -29,8 +30,11 @@ object Main {
           pathEnd {
             CompaniesPage()
           },
-          path("create") {
-            CreateCompanyPage()
+          path(segment) { path =>
+            path match {
+              case "create" => CreateCompanyPage()
+              case id       => CompanyPage(id)
+            }
           }
         )
       },

--- a/app/src/main/scala/pages/CompaniesPage.scala
+++ b/app/src/main/scala/pages/CompaniesPage.scala
@@ -2,8 +2,37 @@ package pages
 
 import layouts.Page
 import com.raquo.laminar.api.L._
+import helpers.ZJS
+import helpers.ZJS.ExtendedZIO
 
 object CompaniesPage {
+
+  var currentContent: Var[HtmlElement] = Var[HtmlElement](div())
+  def buildTable                       =
+    ZJS
+      .client(_.getCompanies)
+      .map { co =>
+        table(
+          className := "table",
+          thead(
+            tr(
+              th("name"),
+              th("website"),
+              th("view")
+            )
+          ),
+          tbody(
+            co.map(c =>
+              tr(
+                td(c.name),
+                td(a(c.url)),
+                td(a("View", href := s"/companies/${c.id}"))
+              )
+            ): _*
+          )
+        )
+      }
+      .map(html => currentContent.set(html))
 
   def apply(): HtmlElement = Page(
     h1("Company stuff here"),
@@ -11,6 +40,10 @@ object CompaniesPage {
       className := "btn btn-outline-info m-2",
       href      := "/companies/create",
       "Add New Company"
+    ),
+    div(
+      onMountCallback(_ => buildTable.runJs),
+      child <-- currentContent.signal
     )
   )
 }

--- a/app/src/main/scala/pages/CompanyPage.scala
+++ b/app/src/main/scala/pages/CompanyPage.scala
@@ -1,0 +1,44 @@
+package pages
+
+import layouts.Page
+import com.raquo.laminar.api.L._
+import helpers.ZJS
+import helpers.ZJS.ExtendedZIO
+object CompanyPage {
+
+  val content: Var[HtmlElement] = Var[HtmlElement](div())
+
+  def buildContent(id: String) =
+    ZJS
+      .client(_.getCompanyById(id))
+      .map {
+        _.map { c =>
+          div(
+            className := "card",
+            div(
+              className := "card-body",
+              h5(className := "card-title", c.name),
+              p(
+                className  := "card-text",
+                "review summary will go here..."
+              ),
+              a(
+                className  := "card-link",
+                href       := c.url,
+                "Website"
+              )
+            )
+          )
+        }.getOrElse(div())
+      }
+      .map(s => content.set(s))
+
+  def apply(companyId: String): HtmlElement = Page(
+    div(
+      onMountCallback(_ => buildContent(companyId).runJs),
+      onUnmountCallback(_ => content.set(div())),
+      className := "container my-lg-5 my-md-3 my-sm-1",
+      child <-- content.signal
+    )
+  )
+}


### PR DESCRIPTION
Not the prettiest for now, but adds a quick table view of companies at `/companies` and a "by id" at `/companies/$id` so we can view data as we round it out.